### PR TITLE
fixed regex to replace multiple german umlauts

### DIFF
--- a/slugs.js
+++ b/slugs.js
@@ -16,10 +16,10 @@ var slug = module.exports = function slug (incString, separator, preserved) {
     }
 
     return incString.toLowerCase().
-        replace('ü', 'ue').
-        replace('ä', 'ae').
-        replace('ö', 'oe').
-        replace('ß', 'ss').
+        replace(/ü/g, 'ue').
+        replace(/ä/g, 'ae').
+        replace(/ö/g, 'oe').
+        replace(/ß/g, 'ss').
         replace(new RegExp('[' + p.join('') + ']', 'g'), ' ').    //  replace preserved characters with spaces
         replace(/-{2,}/g, ' ').     //  remove duplicate spaces
         replace(/^\s\s*/, '').replace(/\s\s*$/, '').    //  trim both sides of string


### PR DESCRIPTION
Hey Aaron.

I have found a mistake in my pull-request :anguished:

Unfortunately it replace only one umlaut of each type. I have overrated the JS replace function (C# developer :wink:). Now I use a regular expression and it works.

Sorry for the inconvenience.

Best regards

René
